### PR TITLE
Beta 1.12 Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,19 @@ This plugin can be used to pre-generate the region of a world around the spawn c
 The generation automatically pauses when a player joins the server (assuming the server was empty before)
 and resumes when the server is empty again. The generation also auto-resumes after a server
 restart. The plugin tracks the ticks per second and pauses the generation when the tps
-is lower than 2.
+is lower than 2 (configurable).
 
 ## Commands
 
 All features can be accessed with the command `/chunkmaster` or the aliases `/chm`, `chunkm`, `cmaster`.
 
-- `/chunkmaster generate [world] [chunk count]` Starts the generation until the specified chunk count or the world border is reached.
+- `/chunkmaster generate [world] [chunk count] [unit]` Starts the generation until the specified chunk count or the world border is reached.
 - `/chunkmaster list` Lists all running generation tasks
 - `/chunkmaster cancel <Task id>` Cancels the generation task with the specified id (if it is running).
 - `/chunkmaster pause` Pauses all generation tasks until the resume command is executed.
 - `/chunkmaster resume` Resumes all paused generation tasks.
 - `/chunkmaster reload` Reloads the configuration file.
+- `/chunkmaster tpchunk <X> <Z>` Teleports you to the specified chunk coordinates.
 
 ## Config
 

--- a/README.md
+++ b/README.md
@@ -39,13 +39,18 @@ generation:
   # The value should be a positive integer.
   period: 2
 
+  # The max amount of chunks that should be generated per step.
+  # Higher values mean higher generation speed but higher performance impact.
+  # The value should be a positive integer.
+  chunks-per-step: 4
+
   # Paper Only
   # The number of already generated chunks that will be skipped for each step.
   # Notice that these still have a performance impact because the server needs to check
   # if the chunk is generated.
   # Higher values mean faster generation but greater performance impact.
   # The value should be a positive integer.
-  chunks-skips-per-step: 5
+  chunk-skips-per-step: 100
 
   # The maximum milliseconds per tick the server is allowed to have
   # during the cunk generation process.

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ idea {
 }
 
 group "net.trivernis"
-version "0.11-beta"
+version "0.12-beta"
 
 sourceCompatibility = 1.8
 

--- a/src/main/kotlin/net/trivernis/chunkmaster/Chunkmaster.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/Chunkmaster.kt
@@ -60,7 +60,7 @@ class Chunkmaster: JavaPlugin() {
     private fun configure() {
         dataFolder.mkdir()
         config.addDefault("generation.period", 2L)
-        config.addDefault("generation.chunks-per-step", 4)
+        config.addDefault("generation.chunks-per-step", 2)
         config.addDefault("generation.chunk-skips-per-step", 100)
         config.addDefault("generation.mspt-pause-threshold", 500L)
         config.addDefault("generation.pause-on-join", true)

--- a/src/main/kotlin/net/trivernis/chunkmaster/Chunkmaster.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/Chunkmaster.kt
@@ -32,8 +32,8 @@ class Chunkmaster: JavaPlugin() {
         generationManager = GenerationManager(this, server)
         generationManager.init()
 
-        getCommand("chunkmaster")?.setExecutor(CommandChunkmaster(this, server))
         getCommand("chunkmaster")?.aliases = mutableListOf("chm", "chunkm", "cmaster")
+        getCommand("chunkmaster")?.setExecutor(CommandChunkmaster(this, server))
 
         server.pluginManager.registerEvents(ChunkmasterEvents(this, server), this)
 
@@ -60,7 +60,8 @@ class Chunkmaster: JavaPlugin() {
     private fun configure() {
         dataFolder.mkdir()
         config.addDefault("generation.period", 2L)
-        config.addDefault("generation.chunks-skips-per-step", 10)
+        config.addDefault("generation.chunks-per-step", 4)
+        config.addDefault("generation.chunk-skips-per-step", 100)
         config.addDefault("generation.mspt-pause-threshold", 500L)
         config.addDefault("generation.pause-on-join", true)
         config.addDefault("generation.max-pending-chunks", 10)

--- a/src/main/kotlin/net/trivernis/chunkmaster/ChunkmasterEvents.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/ChunkmasterEvents.kt
@@ -1,10 +1,12 @@
 package net.trivernis.chunkmaster
 
+import net.trivernis.chunkmaster.lib.generation.GenerationTaskPaper
 import org.bukkit.Server
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerQuitEvent
+import org.bukkit.event.world.WorldSaveEvent
 
 class ChunkmasterEvents(private val chunkmaster: Chunkmaster, private val server: Server) : Listener {
 
@@ -21,8 +23,8 @@ class ChunkmasterEvents(private val chunkmaster: Chunkmaster, private val server
                 server.onlinePlayers.isEmpty()
             ) {
                 if (!playerPaused) {
-                    chunkmaster.generationManager.resumeAll()
                     chunkmaster.logger.info("Server is empty. Resuming chunk generation tasks.")
+                    chunkmaster.generationManager.resumeAll()
                 } else if (chunkmaster.generationManager.paused){
                     chunkmaster.logger.info("Generation was manually paused. Not resuming automatically.")
                     playerPaused = chunkmaster.generationManager.paused
@@ -40,9 +42,22 @@ class ChunkmasterEvents(private val chunkmaster: Chunkmaster, private val server
     fun onPlayerJoin(event: PlayerJoinEvent) {
         if (pauseOnJoin) {
             if (server.onlinePlayers.size == 1 || server.onlinePlayers.isEmpty()) {
+                chunkmaster.logger.info("Pausing generation tasks because of player join.")
                 playerPaused = chunkmaster.generationManager.paused
                 chunkmaster.generationManager.pauseAll()
-                chunkmaster.logger.info("Pausing generation tasks because of player join.")
+            }
+        }
+    }
+
+    /**
+     * Unload all chunks before a save.
+     */
+    @EventHandler
+    fun onWorldSave(event: WorldSaveEvent) {
+        val task = chunkmaster.generationManager.tasks.find { it.generationTask.world == event.world }
+        if (task != null) {
+            if (task.generationTask is GenerationTaskPaper) {
+                task.generationTask.unloadAllChunks()
             }
         }
     }

--- a/src/main/kotlin/net/trivernis/chunkmaster/ChunkmasterEvents.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/ChunkmasterEvents.kt
@@ -23,7 +23,9 @@ class ChunkmasterEvents(private val chunkmaster: Chunkmaster, private val server
                 server.onlinePlayers.isEmpty()
             ) {
                 if (!playerPaused) {
-                    chunkmaster.logger.info("Server is empty. Resuming chunk generation tasks.")
+                    if (chunkmaster.generationManager.pausedTasks.isNotEmpty()) {
+                        chunkmaster.logger.info("Server is empty. Resuming chunk generation tasks.")
+                    }
                     chunkmaster.generationManager.resumeAll()
                 } else if (chunkmaster.generationManager.paused){
                     chunkmaster.logger.info("Generation was manually paused. Not resuming automatically.")
@@ -42,7 +44,9 @@ class ChunkmasterEvents(private val chunkmaster: Chunkmaster, private val server
     fun onPlayerJoin(event: PlayerJoinEvent) {
         if (pauseOnJoin) {
             if (server.onlinePlayers.size == 1 || server.onlinePlayers.isEmpty()) {
-                chunkmaster.logger.info("Pausing generation tasks because of player join.")
+                if (chunkmaster.generationManager.tasks.isNotEmpty()) {
+                    chunkmaster.logger.info("Pausing generation tasks because of player join.")
+                }
                 playerPaused = chunkmaster.generationManager.paused
                 chunkmaster.generationManager.pauseAll()
             }

--- a/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdGenerate.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdGenerate.kt
@@ -37,6 +37,7 @@ class CmdGenerate(private val chunkmaster: Chunkmaster): Subcommand {
             if (args.isNotEmpty()) {
                 if (args[0].toIntOrNull() != null) {
                     stopAfter = args[0].toInt()
+                    worldName = sender.world.name
                 } else {
                     worldName = args[0]
                 }
@@ -58,6 +59,13 @@ class CmdGenerate(private val chunkmaster: Chunkmaster): Subcommand {
                 return false
             }
         }
+        return createTask(sender, worldName, stopAfter)
+    }
+
+    /**
+     * Creates the task with the given arguments.
+     */
+    private fun createTask(sender: CommandSender, worldName: String, stopAfter: Int): Boolean {
         val world = chunkmaster.server.getWorld(worldName)
         val allTasks = chunkmaster.generationManager.allTasks
         return if (world != null && (allTasks.find { it.generationTask.world == world }) == null) {

--- a/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdGenerate.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdGenerate.kt
@@ -100,7 +100,7 @@ class CmdGenerate(private val chunkmaster: Chunkmaster): Subcommand {
                     number.toDouble().pow(2.0).toInt()
                 }
                 "blockradius" -> {
-                    ((number*32)+1).toDouble().pow(2.0).toInt()
+                    ((number.toDouble()+1)/8).pow(2.0).toInt()
                 }
                 else -> number
             }

--- a/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdGenerate.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdGenerate.kt
@@ -7,6 +7,7 @@ import net.trivernis.chunkmaster.lib.Subcommand
 import org.bukkit.command.Command
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
+import kotlin.math.pow
 
 class CmdGenerate(private val chunkmaster: Chunkmaster): Subcommand {
     override val name = "generate"
@@ -23,9 +24,19 @@ class CmdGenerate(private val chunkmaster: Chunkmaster): Subcommand {
         if (args.size == 1) {
             return sender.server.worlds.filter { it.name.indexOf(args[0]) == 0 }
                 .map {it.name}.toMutableList()
+        } else if (args.size == 2) {
+            if (args[0].toIntOrNull() != null) {
+                return units.filter {it.indexOf(args[1]) == 0}.toMutableList()
+            }
+        } else if (args.size > 2) {
+            if (args[1].toIntOrNull() != null) {
+                return units.filter {it.indexOf(args[2]) == 0}.toMutableList()
+            }
         }
         return emptyList<String>().toMutableList()
     }
+    val units = listOf("blockradius", "radius", "diameter")
+
 
     /**
      * Creates a new generation task for the world and chunk count.
@@ -41,8 +52,24 @@ class CmdGenerate(private val chunkmaster: Chunkmaster): Subcommand {
                 } else {
                     worldName = args[0]
                 }
-                if (args.size > 1 && args[1].toIntOrNull() != null) {
-                    stopAfter = args[1].toInt()
+                if (args.size > 1) {
+                    if (args[1].toIntOrNull() != null) {
+                        stopAfter = args[1].toInt()
+                    } else if (args[1] in units) {
+                        when (args[1]) {
+                            "radius" -> {
+                                stopAfter = ((stopAfter * 2)+1).toDouble().pow(2.0).toInt()
+                            }
+                            "diameter" -> {
+                                stopAfter = stopAfter.toDouble().pow(2.0).toInt()
+                            }
+                            "blockradius" -> {
+                                stopAfter = ((stopAfter*32)+1).toDouble().pow(2.0).toInt()
+                            }
+                        }
+                    } else {
+                        worldName = args[1]
+                    }
                 }
             } else {
                 worldName = sender.world.name

--- a/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdGenerate.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdGenerate.kt
@@ -55,21 +55,14 @@ class CmdGenerate(private val chunkmaster: Chunkmaster): Subcommand {
                 if (args.size > 1) {
                     if (args[1].toIntOrNull() != null) {
                         stopAfter = args[1].toInt()
-                    } else if (args[1] in units) {
-                        when (args[1]) {
-                            "radius" -> {
-                                stopAfter = ((stopAfter * 2)+1).toDouble().pow(2.0).toInt()
-                            }
-                            "diameter" -> {
-                                stopAfter = stopAfter.toDouble().pow(2.0).toInt()
-                            }
-                            "blockradius" -> {
-                                stopAfter = ((stopAfter*32)+1).toDouble().pow(2.0).toInt()
-                            }
-                        }
+                    } else if (args[1] in units && args[0].toIntOrNull() != null) {
+                        stopAfter = getStopAfter(stopAfter, args[1])
                     } else {
                         worldName = args[1]
                     }
+                }
+                if (args.size > 2 && args[2] in units && args[1].toIntOrNull() != null) {
+                    stopAfter = getStopAfter(stopAfter, args[2])
                 }
             } else {
                 worldName = sender.world.name
@@ -77,8 +70,13 @@ class CmdGenerate(private val chunkmaster: Chunkmaster): Subcommand {
         } else {
             if (args.isNotEmpty()) {
                 worldName = args[0]
-                if (args.size > 1 && args[1].toIntOrNull() != null) {
-                    stopAfter = args[1].toInt()
+                if (args.size > 1) {
+                    if (args[1].toIntOrNull() != null) {
+                        stopAfter = args[1].toInt()
+                    }
+                }
+                if (args.size > 2 && args[2] in units) {
+                    stopAfter = getStopAfter(stopAfter, args[2])
                 }
             } else {
                 sender.spigot().sendMessage(
@@ -87,6 +85,27 @@ class CmdGenerate(private val chunkmaster: Chunkmaster): Subcommand {
             }
         }
         return createTask(sender, worldName, stopAfter)
+    }
+
+    /**
+     * Returns stopAfter for a given unit
+     */
+    private fun getStopAfter(number: Int, unit: String): Int {
+        if (unit in units) {
+            return when (unit) {
+                "radius" -> {
+                    ((number * 2)+1).toDouble().pow(2.0).toInt()
+                }
+                "diameter" -> {
+                    number.toDouble().pow(2.0).toInt()
+                }
+                "blockradius" -> {
+                    ((number*32)+1).toDouble().pow(2.0).toInt()
+                }
+                else -> number
+            }
+        }
+        return number
     }
 
     /**

--- a/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdReload.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdReload.kt
@@ -1,0 +1,34 @@
+package net.trivernis.chunkmaster.commands
+
+import net.md_5.bungee.api.ChatColor
+import net.md_5.bungee.api.chat.ComponentBuilder
+import net.trivernis.chunkmaster.Chunkmaster
+import net.trivernis.chunkmaster.lib.Subcommand
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+
+class CmdReload(private val chunkmaster: Chunkmaster): Subcommand {
+    override val name = "reload"
+
+    override fun onTabComplete(
+        sender: CommandSender,
+        command: Command,
+        alias: String,
+        args: List<String>
+    ): MutableList<String> {
+        return emptyList<String>().toMutableList()
+    }
+
+    /**
+     * Reload command to reload the config and restart the tasks.
+     */
+    override fun execute(sender: CommandSender, args: List<String>): Boolean {
+        sender.spigot().sendMessage(*ComponentBuilder("Reloading config and restarting tasks...")
+            .color(ChatColor.YELLOW).create())
+        chunkmaster.generationManager.stopAll()
+        chunkmaster.reloadConfig()
+        chunkmaster.generationManager.startAll()
+        sender.spigot().sendMessage(*ComponentBuilder("Config reload complete!").color(ChatColor.GREEN).create())
+        return true
+    }
+}

--- a/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdTpChunk.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/commands/CmdTpChunk.kt
@@ -1,0 +1,52 @@
+package net.trivernis.chunkmaster.commands
+
+import io.papermc.lib.PaperLib
+import net.md_5.bungee.api.ChatColor
+import net.md_5.bungee.api.chat.ComponentBuilder
+import net.trivernis.chunkmaster.lib.Subcommand
+import org.bukkit.Material
+import org.bukkit.command.Command
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+
+class CmdTpChunk: Subcommand {
+    override val name = "tpchunk"
+
+    override fun onTabComplete(
+        sender: CommandSender,
+        command: Command,
+        alias: String,
+        args: List<String>
+    ): MutableList<String> {
+        return emptyList<String>().toMutableList()
+    }
+
+    /**
+     * Teleports the player to a save location in the chunk
+     */
+    override fun execute(sender: CommandSender, args: List<String>): Boolean {
+        if (sender is Player) {
+            if (args.size == 2 && args[0].toIntOrNull() != null && args[1].toIntOrNull() != null) {
+                val location = sender.world.getChunkAt(args[0].toInt(), args[1].toInt()).getBlock(8, 60, 8).location
+
+                while (location.block.blockData.material != Material.AIR) {
+                    location.y++
+                }
+                if (PaperLib.isPaper()) {
+                    PaperLib.teleportAsync(sender, location)
+                } else {
+                    sender.teleport(location)
+                }
+                sender.spigot().sendMessage(*ComponentBuilder("You have been teleportet to chunk")
+                    .color(ChatColor.YELLOW).append("${args[0]}, ${args[1]}").color(ChatColor.BLUE).create())
+                return true
+            } else {
+                return false
+            }
+        } else {
+            sender.spigot().sendMessage(*ComponentBuilder("This command can only be executed by a player!")
+                .color(ChatColor.RED).create())
+            return false
+        }
+    }
+}

--- a/src/main/kotlin/net/trivernis/chunkmaster/commands/CommandChunkmaster.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/commands/CommandChunkmaster.kt
@@ -83,5 +83,8 @@ class CommandChunkmaster(private val chunkmaster: Chunkmaster, private val serve
 
         val cmdReload = CmdReload(chunkmaster)
         commands[cmdReload.name] = cmdReload
+
+        val cmdTpChunk = CmdTpChunk()
+        commands[cmdTpChunk.name] = cmdTpChunk
     }
 }

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/SqlUpdateManager.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/SqlUpdateManager.kt
@@ -15,8 +15,7 @@ class SqlUpdateManager(private val connnection: Connection, private val chunkmas
                 Pair("last_x", "integer NOT NULL DEFAULT 0"),
                 Pair("last_z", "integer NOT NULL DEFAULT 0"),
                 Pair("world", "text UNIQUE NOT NULL DEFAULT 'world'"),
-                Pair("stop_after", "integer DEFAULT -1"),
-                Pair("autostart", "integer DEFAULT 1")
+                Pair("stop_after", "integer DEFAULT -1")
             )
         )
     )

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationManager.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationManager.kt
@@ -226,8 +226,9 @@ class GenerationManager(private val chunkmaster: Chunkmaster, private val server
                 chunkmaster.logger.info(
                     """Task #${task.id} running for "${genTask.world.name}".
                     |Progress ${task.generationTask.count} chunks
-                    |${if (task.generationTask.stopAfter > 0) "(${(task.generationTask.count.toDouble() /
-                            task.generationTask.stopAfter.toDouble()) * 100}%)" else ""}.
+                    |${if (task.generationTask.stopAfter > 0) "(${"%.2f".format((task.generationTask.count.toDouble() /
+                            task.generationTask.stopAfter.toDouble()) * 100)}%)" else ""}.
+                    | Speed: ${"%.1f".format(task.generationSpeed)} chunks/sec,
                     |Last Chunk: ${genTask.lastChunk.x}, ${genTask.lastChunk.z}""".trimMargin("|").replace('\n', ' ')
                 )
                 val updateStatement = chunkmaster.sqliteConnection.prepareStatement(

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationManager.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationManager.kt
@@ -157,7 +157,6 @@ class GenerationManager(private val chunkmaster: Chunkmaster, private val server
      * Starts all generation tasks.
      */
     fun startAll() {
-        chunkmaster.logger.info("Loading saved chunk generation tasks...")
         val savedTasksStatement = chunkmaster.sqliteConnection.prepareStatement("SELECT * FROM generation_tasks")
         savedTasksStatement.execute()
         val res = savedTasksStatement.resultSet
@@ -178,7 +177,9 @@ class GenerationManager(private val chunkmaster: Chunkmaster, private val server
             }
         }
         savedTasksStatement.close()
-        chunkmaster.logger.info("${tasks.size} saved tasks loaded.")
+        if (tasks.isNotEmpty()) {
+            chunkmaster.logger.info("${tasks.size} saved tasks loaded.")
+        }
     }
 
     /**

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTask.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTask.kt
@@ -20,7 +20,7 @@ abstract class GenerationTask(plugin: Chunkmaster, centerChunk: ChunkCoordinates
         Spiral(Pair(centerChunk.x, centerChunk.z), Pair(startChunk.x, startChunk.z))
     protected val loadedChunks: HashSet<Chunk> = HashSet()
     protected var lastChunkCoords = ChunkCoordinates(startChunk.x, startChunk.z)
-    protected val chunkSkips = plugin.config.getInt("generation.chunks-skips-per-step")
+    protected val chunkSkips = plugin.config.getInt("generation.chunk-skips-per-step")
     protected val msptThreshold = plugin.config.getLong("generation.mspt-pause-threshold")
     protected val maxLoadedChunks = plugin.config.getInt("generation.max-loaded-chunks")
     protected val chunksPerStep = plugin.config.getInt("generation.chunks-per-step")

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTask.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTask.kt
@@ -22,6 +22,7 @@ abstract class GenerationTask(plugin: Chunkmaster, centerChunk: Chunk, startChun
     protected val chunkSkips = plugin.config.getInt("generation.chunks-skips-per-step")
     protected val msptThreshold = plugin.config.getLong("generation.mspt-pause-threshold")
     protected val maxLoadedChunks = plugin.config.getInt("generation.max-loaded-chunks")
+    protected val chunksPerStep = plugin.config.getInt("generation.chunks-per-step")
 
     protected var endReachedCallback: (() -> Unit)? = null
         private set

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTask.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTask.kt
@@ -8,7 +8,8 @@ import org.bukkit.World
 /**
  * Interface for generation tasks.
  */
-abstract class GenerationTask(plugin: Chunkmaster, centerChunk: Chunk, startChunk: Chunk) : Runnable {
+abstract class GenerationTask(plugin: Chunkmaster, centerChunk: ChunkCoordinates, startChunk: ChunkCoordinates) :
+    Runnable {
 
     abstract val stopAfter: Int
     abstract val world: World
@@ -35,11 +36,12 @@ abstract class GenerationTask(plugin: Chunkmaster, centerChunk: Chunk, startChun
             val nextChunkCoords = spiral.next()
             return ChunkCoordinates(nextChunkCoords.first, nextChunkCoords.second)
         }
-    var lastChunk: Chunk = startChunk
+
+    val lastChunk: Chunk
         get() {
             return world.getChunkAt(lastChunkCoords.x, lastChunkCoords.z)
         }
-        private set
+
     val nextChunk: Chunk
         get() {
             val next = nextChunkCoordinates

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskPaper.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskPaper.kt
@@ -52,7 +52,12 @@ class GenerationTaskPaper(
                 }
 
                 if (!PaperLib.isChunkGenerated(world, chunk.x, chunk.z)) {
-                    pendingChunks.add(PaperLib.getChunkAtAsync(world, chunk.x, chunk.z, true))
+                    for (i in 0 until chunksPerStep) {
+                        if (!PaperLib.isChunkGenerated(world, chunk.x, chunk.z)) {
+                            pendingChunks.add(PaperLib.getChunkAtAsync(world, chunk.x, chunk.z, true))
+                        }
+                        chunk = nextChunkCoordinates
+                    }
                 }
                 lastChunkCoords = chunk
                 count = spiral.count // set the count to the more accurate spiral count
@@ -66,6 +71,13 @@ class GenerationTaskPaper(
      * This unloads all chunks that were generated but not unloaded yet.
      */
     override fun cancel() {
+        unloadAllChunks()
+    }
+
+    /**
+     * Cancels all pending chunks and unloads all loaded chunks.
+     */
+    fun unloadAllChunks() {
         for (pendingChunk in pendingChunks) {
             if (pendingChunk.isDone) {
                 loadedChunks.add(pendingChunk.get())

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskPaper.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskPaper.kt
@@ -8,7 +8,7 @@ import io.papermc.lib.PaperLib
 
 class GenerationTaskPaper(
     private val plugin: Chunkmaster, override val world: World,
-    centerChunk: Chunk, private val startChunk: Chunk,
+    centerChunk: ChunkCoordinates, private val startChunk: ChunkCoordinates,
     override val stopAfter: Int = -1
 ) : GenerationTask(plugin, centerChunk, startChunk) {
 
@@ -52,11 +52,14 @@ class GenerationTaskPaper(
                 }
 
                 if (!PaperLib.isChunkGenerated(world, chunk.x, chunk.z)) {
-                    for (i in 0 until chunksPerStep) {
+                    for (i in 0 until minOf(chunksPerStep, (stopAfter - count) - 1)) {
                         if (!PaperLib.isChunkGenerated(world, chunk.x, chunk.z)) {
                             pendingChunks.add(PaperLib.getChunkAtAsync(world, chunk.x, chunk.z, true))
                         }
                         chunk = nextChunkCoordinates
+                    }
+                    if (!PaperLib.isChunkGenerated(world, chunk.x, chunk.z)) {
+                        pendingChunks.add(PaperLib.getChunkAtAsync(world, chunk.x, chunk.z, true))
                     }
                 }
                 lastChunkCoords = chunk

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskSpigot.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskSpigot.kt
@@ -37,12 +37,15 @@ class GenerationTaskSpigot(
                     return
                 }
 
-                val chunk = nextChunkCoordinates
+                var chunk = nextChunkCoordinates
 
                 if (!world.isChunkGenerated(chunk.x, chunk.z)) {
-                    val chunkInstance = world.getChunkAt(chunk.x, chunk.z)
-                    chunkInstance.load(true)
-                    loadedChunks.add(chunkInstance)
+                    for (i in 0 until chunksPerStep) {
+                        val chunkInstance = world.getChunkAt(chunk.x, chunk.z)
+                        chunkInstance.load(true)
+                        loadedChunks.add(chunkInstance)
+                        chunk = nextChunkCoordinates
+                    }
                 }
                 lastChunkCoords = chunk
                 count = spiral.count // set the count to the more accurate spiral count

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskSpigot.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskSpigot.kt
@@ -6,7 +6,7 @@ import org.bukkit.World
 
 class GenerationTaskSpigot(
     private val plugin: Chunkmaster, override val world: World,
-    centerChunk: Chunk, private val startChunk: Chunk,
+    centerChunk: ChunkCoordinates, private val startChunk: ChunkCoordinates,
     override val stopAfter: Int = -1
 ) : GenerationTask(plugin, centerChunk, startChunk) {
 
@@ -37,14 +37,14 @@ class GenerationTaskSpigot(
                     return
                 }
 
-                var chunk = nextChunkCoordinates
+                var chunk = lastChunkCoords
 
                 if (!world.isChunkGenerated(chunk.x, chunk.z)) {
-                    for (i in 0 until chunksPerStep) {
+                    for (i in 0 until minOf(chunksPerStep, (stopAfter - count) - 1)) {
+                        chunk = nextChunkCoordinates
                         val chunkInstance = world.getChunkAt(chunk.x, chunk.z)
                         chunkInstance.load(true)
                         loadedChunks.add(chunkInstance)
-                        chunk = nextChunkCoordinates
                     }
                 }
                 lastChunkCoords = chunk

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskSpigot.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/GenerationTaskSpigot.kt
@@ -37,15 +37,18 @@ class GenerationTaskSpigot(
                     return
                 }
 
-                var chunk = lastChunkCoords
+                var chunk = nextChunkCoordinates
 
                 if (!world.isChunkGenerated(chunk.x, chunk.z)) {
-                    for (i in 0 until minOf(chunksPerStep, (stopAfter - count) - 1)) {
-                        chunk = nextChunkCoordinates
+                    for (i in 0 until minOf(chunksPerStep, stopAfter - count)) {
                         val chunkInstance = world.getChunkAt(chunk.x, chunk.z)
                         chunkInstance.load(true)
                         loadedChunks.add(chunkInstance)
+                        chunk = nextChunkCoordinates
                     }
+                    val chunkInstance = world.getChunkAt(chunk.x, chunk.z)
+                    chunkInstance.load(true)
+                    loadedChunks.add(chunkInstance)
                 }
                 lastChunkCoords = chunk
                 count = spiral.count // set the count to the more accurate spiral count

--- a/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/RunningTaskEntry.kt
+++ b/src/main/kotlin/net/trivernis/chunkmaster/lib/generation/RunningTaskEntry.kt
@@ -7,6 +7,29 @@ class RunningTaskEntry(
     val task: BukkitTask,
     override val generationTask: GenerationTask
 ) : TaskEntry {
+
+    private var lastProgress: Pair<Long, Int>? = null
+
+    /**
+     * Returns the generation Speed
+     */
+    val generationSpeed: Double?
+        get() {
+            var generationSpeed: Double? = null
+            if (lastProgress != null) {
+                val chunkDiff = generationTask.count - lastProgress!!.second
+                val timeDiff = (System.currentTimeMillis() - lastProgress!!.first).toDouble()/1000
+                generationSpeed = chunkDiff.toDouble()/timeDiff
+            }
+            lastProgress = Pair(System.currentTimeMillis(), generationTask.count)
+            return generationSpeed
+        }
+
+    init {
+        lastProgress = Pair(System.currentTimeMillis(), generationTask.count)
+    }
+
+
     override fun cancel() {
         task.cancel()
         generationTask.cancel()

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 main: net.trivernis.chunkmaster.Chunkmaster
 name: Chunkmaster
-version: '0.11-beta'
+version: '0.12-beta'
 description: Chunk commands plugin.
 author: Trivernis
 website: trivernis.net

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -9,7 +9,14 @@ commands:
   chunkmaster:
     description: Main command
     permission: chunkmaster.chunkmaster
-    usage: /chunkmaster <generate|list|pause|resume|cancel|reload>
+    usage: |
+      /<command> generate [<world>, <chunk-count>] - generates chunks starting from the spawn until the chunk-count is reached
+      /<command> cancel <task-id> - cancels the generation task with the task-id
+      /<command> list - lists all running and paused generation tasks
+      /<command> pause - pauses all generation tasks
+      /<command> resume - resumes all generation tasks
+      /<command> reload - reloads the configuration and restarts all tasks
+      /<command> tpchunk <chunkX> <chunkZ> - teleports you to the chunk with the given chunk coordinates
     aliases:
       - chm
       - chunkm
@@ -32,6 +39,9 @@ permissions:
     default: op
   chunkmaster.reload:
     description: Allows the reload subcommand.
+    default: op
+  chunkmaster.tpchunk:
+    description: Allows the tpchunk subcommand.
     default: op
   chunkmaster.chunkmaster:
     description: Allows Chunkmaster commands.


### PR DESCRIPTION
# Changes

- (probably) Fixed #3 by resolving or canceling pending chunks on world save
- Fixed verbose console output on no running tasks
- Added `/chunkmaster tpchunk` command to teleport to chunks
- Added a unit to the generation command to specify if the given number is the radius, the diameter, blockradius or a chunkcount (no value given).
- Added option to generate multiple chunks in one generation step
- Added generation speed to periodical report