### PR TITLE
Update Kotlin and PaperLib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     id 'idea'
-    id 'org.jetbrains.kotlin.jvm' version '1.3.50'
+    id 'org.jetbrains.kotlin.jvm' version '1.4.10'
     id 'com.github.johnrengelman.shadow' version '2.0.4'
 }
 
@@ -57,7 +57,7 @@ dependencies {
     compileOnly "com.destroystokyo.paper:paper-api:1.14.4-R0.1-SNAPSHOT"
     compileOnly "org.dynmap:dynmap-api:2.0"
     compileOnly group: 'org.xerial', name: 'sqlite-jdbc', version: '3.28.0'
-    compile "io.papermc:paperlib:1.0.2"
+    compile "io.papermc:paperlib:1.0.6"
     compile "org.bstats:bstats-bukkit:1.5"
 }
 


### PR DESCRIPTION
That's it. I just made it so that the build will no longer fail as Kotlin is up to date, plus the added benefit of PaperLib being up to date.